### PR TITLE
Use gatsby's fork of reach-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^4.5.7",
     "@gatsbyjs/reach-router": "^1.3.9",
-    "@reach/router": "^1.3.4",
     "classnames": "^2.3.1",
     "deepmerge": "^4.2.2",
     "eslint-config-standard-jsx": "^11.0.0",
@@ -35,6 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": ">=7.12.3 <8.0.0",
+    "@types/gatsbyjs__reach-router": "^1.3.0",
     "@types/node": "^18.0.3",
     "@types/reach__router": "^1.3.10",
     "@types/react": "^18.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@babel/core': '>=7.12.3 <8.0.0'
   '@fontsource/atkinson-hyperlegible': ^4.5.7
   '@gatsbyjs/reach-router': ^1.3.9
-  '@reach/router': ^1.3.4
+  '@types/gatsbyjs__reach-router': ^1.3.0
   '@types/node': ^18.0.3
   '@types/reach__router': ^1.3.10
   '@types/react': ^18.0.15
@@ -51,7 +51,6 @@ specifiers:
 dependencies:
   '@fontsource/atkinson-hyperlegible': 4.5.8
   '@gatsbyjs/reach-router': 1.3.9_biqbaboplfbrettd7655fr4n2y
-  '@reach/router': 1.3.4_biqbaboplfbrettd7655fr4n2y
   classnames: 2.3.1
   deepmerge: 4.2.2
   eslint-config-standard-jsx: 11.0.0_3wow733677dxwz5dijvkdb255q
@@ -73,6 +72,7 @@ dependencies:
 
 devDependencies:
   '@babel/core': 7.18.10
+  '@types/gatsbyjs__reach-router': 1.3.0
   '@types/node': 18.7.6
   '@types/reach__router': 1.3.10
   '@types/react': 18.0.17
@@ -3584,20 +3584,6 @@ packages:
       source-map: 0.7.4
       webpack: 5.74.0
 
-  /@reach/router/1.3.4_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==}
-    peerDependencies:
-      react: 15.x || 16.x || 16.4.0-alpha.0911da3
-      react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
-    dependencies:
-      create-react-context: 0.3.0_sh5qlbywuemxd2y3xkrw2y2kr4
-      invariant: 2.2.4
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-lifecycles-compat: 3.0.4
-    dev: false
-
   /@samverschueren/stream-to-observable/0.3.1_rxjs@6.6.7:
     resolution: {integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==}
     engines: {node: '>=6'}
@@ -3789,6 +3775,12 @@ packages:
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+
+  /@types/gatsbyjs__reach-router/1.3.0:
+    resolution: {integrity: sha512-7dfI9peaJk7TuIIaW8r6r8UaobvR+zqyc/x8pQpqwOFHCiLXl49TUxMoapFv1BQFAbT9UKrvlsijJk7X5r18lQ==}
+    dependencies:
+      '@types/reach__router': 1.3.10
+    dev: true
 
   /@types/get-port/3.2.0:
     resolution: {integrity: sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==}
@@ -6117,18 +6109,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/runtime': 7.18.9
-
-  /create-react-context/0.3.0_sh5qlbywuemxd2y3xkrw2y2kr4:
-    resolution: {integrity: sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==}
-    peerDependencies:
-      prop-types: ^15.0.0
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      gud: 1.0.0
-      prop-types: 15.8.1
-      react: 18.2.0
-      warning: 4.0.3
-    dev: false
 
   /create-require/1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -9593,10 +9573,6 @@ packages:
     resolution: {integrity: sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: true
-
-  /gud/1.0.0:
-    resolution: {integrity: sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==}
-    dev: false
 
   /gzip-size/6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -15567,12 +15543,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /warning/4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/src/meta.tsx
+++ b/src/meta.tsx
@@ -1,6 +1,6 @@
 import { graphql, useStaticQuery } from 'gatsby'
 import React, { ReactElement } from 'react'
-import { useLocation } from '@reach/router'
+import { useLocation } from '@gatsbyjs/reach-router'
 
 interface MetaProps {
   title?: string


### PR DESCRIPTION
It was giving peer dependencies issue.

`@reach/router` is essentially dead and people are meant to use `react-router` instead. It seems like gatsby is not ready to migrate and they're maintaining a fork with modern react compatibility