### PR TITLE
Stop using `eslint-config-standard-react`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: [
     'standard-with-typescript',
     'standard-jsx',
-    'standard-react',
     'plugin:react-hooks/recommended'
   ],
   parserOptions: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "classnames": "^2.3.1",
     "deepmerge": "^4.2.2",
     "eslint-config-standard-jsx": "^11.0.0",
-    "eslint-config-standard-react": "^11.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.30.1",
     "gatsby": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,6 @@ specifiers:
   deepmerge: ^4.2.2
   eslint: ^8.0.1
   eslint-config-standard-jsx: ^11.0.0
-  eslint-config-standard-react: ^11.0.1
   eslint-config-standard-with-typescript: ^22.0.0
   eslint-plugin-import: ^2.26.0
   eslint-plugin-n: ^15.0.0
@@ -54,7 +53,6 @@ dependencies:
   classnames: 2.3.1
   deepmerge: 4.2.2
   eslint-config-standard-jsx: 11.0.0_3wow733677dxwz5dijvkdb255q
-  eslint-config-standard-react: 11.0.1_3wow733677dxwz5dijvkdb255q
   eslint-plugin-node: 11.1.0_eslint@8.22.0
   eslint-plugin-react: 7.30.1_eslint@8.22.0
   gatsby: 4.21.0_xgwl3ufwispssl2tn6wv4uvmi4
@@ -7213,16 +7211,6 @@ packages:
     peerDependencies:
       eslint: ^8.8.0
       eslint-plugin-react: ^7.28.0
-    dependencies:
-      eslint: 8.22.0
-      eslint-plugin-react: 7.30.1_eslint@8.22.0
-    dev: false
-
-  /eslint-config-standard-react/11.0.1_3wow733677dxwz5dijvkdb255q:
-    resolution: {integrity: sha512-4WlBynOqBZJRaX81CBcIGDHqUiqxvw4j/DbEIICz8QkMs3xEncoPgAoysiqCSsg71X92uhaBc8sgqB96smaMmg==}
-    peerDependencies:
-      eslint: ^7.12.1
-      eslint-plugin-react: ^7.21.5
     dependencies:
       eslint: 8.22.0
       eslint-plugin-react: 7.30.1_eslint@8.22.0


### PR DESCRIPTION
They haven't updated the library in a while even tho a PR to support
eslint 18 was merged. Currenlty, it's blocking all updates because of
busted peer dependencies.